### PR TITLE
Fix undo/redo state capture

### DIFF
--- a/typographymaker.html
+++ b/typographymaker.html
@@ -1925,12 +1925,16 @@
                     if (undoStack.length > 0) {
                         let lastState = undoStack.pop();
                         // 현재 상태를 redoStack에 저장
+                        let timelineBody = document.getElementById("timelineBody");
                         let currentState = {
-                            clipsData: JSON.parse(
-                                JSON.stringify(clipsData)
-                            ),
+                            clipsData: structuredClone(clipsData),
                             currentTime: currentTime,
                             totalDuration: totalDuration,
+                            trackCount: trackList.length,
+                            timelineScroll: timelineBody.scrollLeft,
+                            previewBgColor: document.getElementById("previewBgColor").value,
+                            bgMusicFileName: document.getElementById("bgMusicFileName").textContent,
+                            bgVolume: document.getElementById("bgVolumeControl").value,
                         };
                         redoStack.push(currentState);
                         restoreState(lastState);
@@ -1941,12 +1945,16 @@
                 else if (e.ctrlKey && e.key.toLowerCase() === "y") {
                     if (redoStack.length > 0) {
                         let nextState = redoStack.pop();
+                        let timelineBody = document.getElementById("timelineBody");
                         let currentState = {
-                            clipsData: JSON.parse(
-                                JSON.stringify(clipsData)
-                            ),
+                            clipsData: structuredClone(clipsData),
                             currentTime: currentTime,
                             totalDuration: totalDuration,
+                            trackCount: trackList.length,
+                            timelineScroll: timelineBody.scrollLeft,
+                            previewBgColor: document.getElementById("previewBgColor").value,
+                            bgMusicFileName: document.getElementById("bgMusicFileName").textContent,
+                            bgVolume: document.getElementById("bgVolumeControl").value,
                         };
                         undoStack.push(currentState);
                         restoreState(nextState);
@@ -2717,7 +2725,7 @@
             }
 
             function updatePreview(t) {
-                saveState();
+                // 미리보기 갱신은 빈번하게 호출되므로 상태를 저장하지 않는다
                 const preview = document.getElementById("preview");
                 const previewContent = preview.querySelector(".preview-content");
                 previewContent.innerHTML = "";


### PR DESCRIPTION
## Summary
- update undo/redo logic so that full state is stored
- avoid saving state on every preview refresh

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fbbbef050832a9eec5b37c4fc1081